### PR TITLE
Add option to disable autoloading of root schedule

### DIFF
--- a/lib/schked/config.rb
+++ b/lib/schked/config.rb
@@ -4,7 +4,8 @@ require "logger"
 
 module Schked
   class Config
-    attr_writer :logger
+    attr_writer :logger,
+      :do_not_load_root_schedule
 
     def paths
       @paths ||= []
@@ -16,6 +17,10 @@ module Schked
 
     def logger
       @logger ||= Logger.new($stdout).tap { |l| l.level = Logger::INFO }
+    end
+
+    def do_not_load_root_schedule?
+      !!@do_not_load_root_schedule
     end
 
     def register_callback(name, &block)

--- a/lib/schked/railtie.rb
+++ b/lib/schked/railtie.rb
@@ -6,7 +6,10 @@ module Schked
   class Railtie < Rails::Railtie
     class PathsConfig
       def self.call(app)
-        if (root_schedule = app.root.join("config", "schedule.rb")).exist?
+        return if Schked.config.do_not_load_root_schedule?
+
+        root_schedule = app.root.join("config", "schedule.rb")
+        if root_schedule.exist?
           path = root_schedule.to_s
           Schked.config.paths << path unless Schked.config.paths.include?(path)
         end

--- a/spec/rails/railtie_spec.rb
+++ b/spec/rails/railtie_spec.rb
@@ -4,7 +4,11 @@ require "rails_helper"
 
 describe Schked::Railtie do
   describe "schked.config" do
-    subject(:config) { Schked.config }
+    let(:config) { Schked::Config.new }
+
+    before do
+      allow(Schked).to receive(:config).and_return(config)
+    end
 
     context "when by default root schedule doesn't exist" do
       it { expect(config.paths).to be_empty }
@@ -34,6 +38,14 @@ describe Schked::Railtie do
         it "does not add it twice" do
           initializer.call(double("app", root: Rails.root))
           expect(config.paths).to match_array([schedule_path])
+        end
+      end
+
+      context "when passed do_not_load_root_schedule config option" do
+        before { config.do_not_load_root_schedule = true }
+
+        it "doesn't add root schedule to paths" do
+          expect(config.paths).to be_empty
         end
       end
     end


### PR DESCRIPTION
# Context

<!--
Short description about the feature and the motivation/issue behind it
-->

Sometimes we already have an added scheduler, for example, Whenever gem that also wants `config/schedule.rb` file to load.

## Related tickets

-

# What's inside

<!--
List of features and changes (or highlights) (from the code perspective)
The purpose of this list is to track the progress if it's WIP (use checkboxes)
and to emphasize the critical parts (which you'd like to pay reviewers attention to)
-->
- [x] Added a config option `do_not_load_root_schedule`

# Checklist:

- [x] I have added tests
- [ ] I have made corresponding changes to the documentation
