### PR TITLE
Add Ruby 3.0 and 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,17 +12,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # waiting for the fix https://github.com/thoughtbot/appraisal/issues/186 to test on Ruby 3
-        ruby: [ '2.6', '2.7' ]
+        # waiting for the release with the fix for https://github.com/thoughtbot/appraisal/issues/199 to test on Ruby 3.2
+        ruby: [ '2.6', '2.7', '3.0', '3.1' ]
     env:
       RUBY_IMAGE: ${{ matrix.ruby }}
     name: Ruby ${{ matrix.ruby }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: '3.0' 
       - name: Install dependencies
         run: |
           gem install dip


### PR DESCRIPTION
Also updates the checkout action version and quotes an existing '3.0' to avoid truncation

Ruby 3.2 cannot yet be added because of a blocking appraisal issue.  Updated the comment in the file to reflect that.

# Context

CI should run against current Rubies.

## Related tickets

None

# What's inside

* Added Ruby 3.0 and 3.1 to the test matrix
* Quoted a 3.0 to insure that Ruby 3.0 is loaded by the setup-ruby action.  Currently the 3.0 is being truncated to 3, leading to Ruby 3.2 getting loaded
* Updated the checkout action version  

# Checklist:

Tests are not applicable.  No changes to the docs were required.
