### PR TITLE
feat: add around_job callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,19 @@ Schked.config.register_callback(:on_error) do |job, error|
 end
 ```
 
-There are `:before_start` and `:after_finish` callbacks as well.
+There are `:before_start`, `:after_finish` and `:around_job` callbacks as well.
+
+Warning: `:before_start` and `:after_finish` callbacks are executed in the scheduler thread, not in the work threads (the threads where the job execution really happens).
+
+`:around_job` callback is executed in the job's thread.
+
+```ruby
+Schked.config.register_callback(:around_job) do |job, &block|
+  ...
+  block.call
+  ...
+end
+```
 
 ### Logging
 

--- a/lib/schked/config.rb
+++ b/lib/schked/config.rb
@@ -35,6 +35,19 @@ module Schked
       end
     end
 
+    def fire_around_callback(name, job, calls = callbacks[name], &block)
+      return yield if calls.none?
+
+      calls.first.call(job) do
+        calls = calls.drop(1)
+        if calls.any?
+          fire_around_callback(name, job, calls, &block)
+        else
+          yield
+        end
+      end
+    end
+
     def redis_servers
       @redis_servers ||= [ENV.fetch("REDIS_URL", "redis://127.0.0.1:6379")]
     end

--- a/lib/schked/worker.rb
+++ b/lib/schked/worker.rb
@@ -67,6 +67,10 @@ module Schked
         cfg.fire_callback(:before_start, job, time)
       end
 
+      scheduler.define_singleton_method(:around_trigger) do |job, &block|
+        cfg.fire_around_callback(:around_job, job, &block)
+      end
+
       scheduler.define_singleton_method(:on_post_trigger) do |job, time|
         cfg.logger.info("Finished task: #{extract_job_name(job)}")
 

--- a/schked.gemspec
+++ b/schked.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "combustion", "~> 1.3"
   s.add_development_dependency "pry-byebug", "~> 3.9"
   s.add_development_dependency "rake", "~> 13.0"
+  s.add_development_dependency "redis", "~> 5.0"
   s.add_development_dependency "rspec", "~> 3.9"
   s.add_development_dependency "standard", "~> 0.4"
 end


### PR DESCRIPTION
# Context

`before_start` and `after_finish` (`on_pre_trigger` and `on_post_trigger` for `rufus-scheduler`) callbacks are triggered outside of the job thread as [rufus-scheduler](https://github.com/jmettraux/rufus-scheduler#rufusscheduler-on_pre_trigger-and-on_post_trigger-callbacks) doc said.

It's not convenient when we need to track data between these two callback (Sentry [transaction](https://docs.sentry.io/platforms/ruby/guides/rails/performance/instrumentation/custom-instrumentation/?original_referrer=https%3A%2F%2Fwww.google.com%2F) for example)

There is [around_trigger](https://github.com/jmettraux/rufus-scheduler#rufusscheduleraround_trigger) callback that execute inside the job's thread.

So I've added `around_job` callback implemenatation for Schked.

Also, `around_job` callback requires a different approach for execution so I've added `fire_around_callback` method.
The current `fire_callback` calls callbacks one by one and this way we will be executing a job's code as many times as we have registered `around_job` callbacks. 

`fire_around_callback` executes job's code only once by recursion callbacks call.

## Related tickets



# What's inside

<!--
List of features and changes (or highlights) (from the code perspective)
The purpose of this list is to track the progress if it's WIP (use checkboxes)
and to emphasize the critical parts (which you'd like to pay reviewers attention to)
-->
- [x] add `around_job` callback

# Checklist:

- [x] I have added tests
- [x] I have made corresponding changes to the documentation
